### PR TITLE
Question about metadata handling

### DIFF
--- a/miniopy_async/helpers.py
+++ b/miniopy_async/helpers.py
@@ -314,10 +314,11 @@ def _metadata_to_headers(metadata):
             ) from exc
         return value
 
-    def normalize_value(values):
-        if not isinstance(values, (list, tuple)):
-            values = [values]
-        return [to_string(value) for value in values]
+    def normalize_value(value):
+        #if not isinstance(values, (list, tuple)):
+        #    values = [values]
+        #return [to_string(value) for value in values]
+        return to_string(value)
 
     return {
         normalize_key(key): normalize_value(value)


### PR DESCRIPTION
Merry Christmas!

When trying to set some metadata while using `put_object` method, I ran into the following error:

```
[...]
  File "/home/hakiergrzonzo/.cache/pypoetry/virtualenvs/backend-Ubo4YBJb-py3.10/lib/python3.10/site-packages/miniopy_async/api.py", line 2297, in put_object
    raise exc
  File "/home/hakiergrzonzo/.cache/pypoetry/virtualenvs/backend-Ubo4YBJb-py3.10/lib/python3.10/site-packages/miniopy_async/api.py", line 2247, in put_object
    return await self._put_object(
  File "/home/hakiergrzonzo/.cache/pypoetry/virtualenvs/backend-Ubo4YBJb-py3.10/lib/python3.10/site-packages/miniopy_async/api.py", line 2026, in _put_object
    response = await self._execute(
  File "/home/hakiergrzonzo/.cache/pypoetry/virtualenvs/backend-Ubo4YBJb-py3.10/lib/python3.10/site-packages/miniopy_async/api.py", line 371, in _execute
    return await self._url_open(
  File "/home/hakiergrzonzo/.cache/pypoetry/virtualenvs/backend-Ubo4YBJb-py3.10/lib/python3.10/site-packages/miniopy_async/api.py", line 269, in _url_open
    response = await session.request(
  File "/home/hakiergrzonzo/.cache/pypoetry/virtualenvs/backend-Ubo4YBJb-py3.10/lib/python3.10/site-packages/aiohttp/client.py", line 558, in _request
    resp = await req.send(conn)
  File "/home/hakiergrzonzo/.cache/pypoetry/virtualenvs/backend-Ubo4YBJb-py3.10/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line670, in send
    await writer.write_headers(status_line, self.headers)
  File "/home/hakiergrzonzo/.cache/pypoetry/virtualenvs/backend-Ubo4YBJb-py3.10/lib/python3.10/site-packages/aiohttp/http_writer.py", line 130, in write_headers
    buf = _serialize_headers(status_line, headers)
  File "aiohttp/_http_writer.pyx", line 132, in aiohttp._http_writer._serialize_headers
  File "aiohttp/_http_writer.pyx", line 109, in aiohttp._http_writer.to_str
TypeError: Cannot serialize non-str key ['2022-10-17 PZU 1666713332.pdf']
```

I managed to trace back the issue to the prefixing logic in `helpers`, which has caused the headers to be encoded like so:

```
{'X-Amz-Meta-original_filename': ['2022-10-17 PZU 1666713332.pdf']}
```

As a result I have a couple questions about the `normalize_value` function. Is there a specific reason for it to force the data to be list? Would forcing each key to have a string value be sufficient? 

This PR contains a ,,fix" to the mentioned issue, let me know if you are open to merging it so I can clean it up.