### PR TITLE
Iterate properly if list_objects result is truncated

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -273,6 +273,9 @@ async def main():
     objects = await client.list_objects("my-bucket")
     for obj in objects:
         print('obj:',obj)
+    
+    async for obj in client.list_objects("my-bucket"):
+        print('obj:',obj)
 
     # List objects information whose names starts with "my/prefix/".
     print('example two')

--- a/examples/simple_examples/list_objects.py
+++ b/examples/simple_examples/list_objects.py
@@ -43,6 +43,9 @@ async def main():
     for obj in objects:
         print("obj:", obj)
 
+    async for obj in client.list_objects("my-bucket"):
+        print("obj:", obj)
+
     # List objects information recursively.
     print("example three")
     objects = await client.list_objects("my-bucket", recursive=True)

--- a/miniopy_async/api.py
+++ b/miniopy_async/api.py
@@ -4173,6 +4173,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             include_version = True
 
         is_truncated = True
+        objects = []
         while is_truncated:
             query = {}
             if include_version:
@@ -4208,18 +4209,19 @@ class Minio:  # pylint: disable=too-many-public-methods
                 )
 
                 (
-                    objects,
+                    partial_objects,
                     is_truncated,
                     start_after,
                     version_id_marker,
                 ) = await parse_list_objects(response)
+                objects += partial_objects
 
             if not include_version:
                 version_id_marker = None
                 if not use_api_v1:
                     continuation_token = start_after
 
-            return objects
+        return objects
 
     async def _list_multipart_uploads(
         self,

--- a/miniopy_async/api.py
+++ b/miniopy_async/api.py
@@ -2460,6 +2460,9 @@ class Minio:  # pylint: disable=too-many-public-methods
                 for obj in objects:
                     print('obj:',obj)
 
+                async for obj in client.list_objects("my-bucket"):
+                    print('obj:',obj)
+
                 # List objects information whose names starts with "my/prefix/".
                 print('example two')
                 objects = await client.list_objects("my-bucket",


### PR DESCRIPTION
Do not prematurely exit loop when retrieving list of objects in a bucket (addresses #26)