### PR TITLE
feature(api): Add Custom `aiohttp.ClientSession` For `fget_object`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1436,16 +1436,18 @@ Downloads data of an object to file.
 
 __Parameters__
 
-| Param                | Type             | Description                                          |
-|:---------------------|:-----------------|:-----------------------------------------------------|
-| `bucket_name`        | _str_            | Name of the bucket.                                  |
-| `object_name`        | _str_            | Object name in the bucket.                           |
-| `file_path`          | _str_            | Name of file to download.                            |
-| `request_headers`    | _dict_           | Any additional headers to be added with GET request. |
-| `ssec`               | _SseCustomerKey_ | Server-side encryption customer key.                 |
-| `version_id`         | _str_            | Version-ID of the object.                            |
-| `extra_query_params` | _dict_           | Extra query parameters for advanced usage.           |
-| `tmp_file_path`      | _str_            | Path to a temporary file.                            |
+| Param                | Type                    | Description                                          |
+|:---------------------|:------------------------|:-----------------------------------------------------|
+| `bucket_name`        | _str_                   | Name of the bucket.                                  |
+| `object_name`        | _str_                   | Object name in the bucket.                           |
+| `file_path`          | _str_                   | Name of file to download.                            |
+| `request_headers`    | _dict_                  | Any additional headers to be added with GET request. |
+| `ssec`               | _SseCustomerKey_        | Server-side encryption customer key.                 |
+| `version_id`         | _str_                   | Version-ID of the object.                            |
+| `extra_query_params` | _dict_                  | Extra query parameters for advanced usage.           |
+| `tmp_file_path`      | _str_                   | Path to a temporary file.                            |
+| `session`            | _aiohttp.ClientSession_ | aiohttp.ClientSession object.                        |
+
 
 __Return Value__
 

--- a/miniopy_async/api.py
+++ b/miniopy_async/api.py
@@ -1405,6 +1405,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         version_id=None,
         extra_query_params=None,
         tmp_file_path=None,
+        session=None
     ):
         """
         Downloads data of an object to file.
@@ -1418,6 +1419,7 @@ class Minio:  # pylint: disable=too-many-public-methods
         :param version_id: Version-ID of the object.
         :param extra_query_params: Extra query parameters for advanced usage.
         :param tmp_file_path: Path to a temporary file.
+        :param session: :class:`aiohttp.ClientSession()` object.
         :return: Object information.
 
         Example::
@@ -1484,12 +1486,13 @@ class Minio:  # pylint: disable=too-many-public-methods
             offset = 0
 
         response = None
+        _session = session or aiohttp.ClientSession()
         try:
-            async with aiohttp.ClientSession() as session:
+            async with _session as aio_session:
                 response = await self.get_object(
                     bucket_name,
                     object_name,
-                    session,
+                    aio_session,
                     offset=offset,
                     request_headers=request_headers,
                     ssec=ssec,


### PR DESCRIPTION
Adding an option to provide a custom `aiohttp.ClientSession` for
`fget_object` funtion.

Resolves #30.
