### PR TITLE
fix(api): Fix `copy_object` Method

### DIFF
--- a/miniopy_async/api.py
+++ b/miniopy_async/api.py
@@ -1748,7 +1748,7 @@ class Minio:  # pylint: disable=too-many-public-methods
             return await self.compose_object(
                 bucket_name,
                 object_name,
-                ComposeSource.of(source),
+                [ComposeSource.of(source)],
                 sse=sse,
                 metadata=metadata,
                 tags=tags,


### PR DESCRIPTION
`copy_object` method is expected to pass a list of `ComposeObject` to
`compose_object` method.

Resolves #32.