### PR TITLE
‌feat: Add `managed_upload` context manager for simplified multipart uploads‌

### DIFF
--- a/examples/simple_examples/multipart_uploader.py
+++ b/examples/simple_examples/multipart_uploader.py
@@ -33,7 +33,7 @@ async def main():
         "my-bucket",
         "my-object",
     ) as uploader:
-        await uploader.upload_part(b"hello ", 1)
+        await uploader.upload_part(b"hello" * 1024 * 1024, 1)
         await uploader.upload_part(b"world", 2)
     result = uploader.result
     print(
@@ -50,7 +50,7 @@ async def main():
         "my-bucket",
         "my-object",
     )
-    await uploader.upload_part(b"hello ", 1)
+    await uploader.upload_part(b"hello" * 1024 * 1024, 1)
     await uploader.upload_part(b"world", 2)
     result = await uploader.complete()
     print(
@@ -67,7 +67,7 @@ async def main():
         "my-bucket",
         "my-object",
     )
-    await uploader.upload_part(b"hello ", 1)
+    await uploader.upload_part(b"hello", 1)
     await uploader.abort()
 
     # Parallel upload
@@ -78,7 +78,7 @@ async def main():
         "my-object",
     ) as uploader:
         for i in range(1, 11):
-            data = f"part {i}".encode("utf-8")
+            data = (f"part{i}" * 1024 * 1024).encode("utf-8")
             tasks.append(uploader.upload_part(data, i))
         await asyncio.gather(*tasks)
     result = uploader.result

--- a/examples/simple_examples/multipart_uploader.py
+++ b/examples/simple_examples/multipart_uploader.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+# Asynchronous MinIO Client SDK for Python
+# (C) 2025 L-ING <hlf01@icloud.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+from miniopy_async import Minio
+
+client = Minio(
+    "play.min.io",
+    access_key="Q3AM3UQ867SPQQA43P2F",
+    secret_key="zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
+    secure=True,  # http for False, https for True
+)
+
+
+async def main():
+    # Use context manager
+    print("example one")
+    async with client.multipart_uploader(
+        "my-bucket",
+        "my-object",
+    ) as uploader:
+        await uploader.upload_part(b"hello ", 1)
+        await uploader.upload_part(b"world", 2)
+    result = uploader.result
+    print(
+        "created {0} object; etag: {1}, version-id: {2}".format(
+            result.object_name,
+            result.etag,
+            result.version_id,
+        ),
+    )
+
+    # Use directly
+    print("example two")
+    uploader = client.multipart_uploader(
+        "my-bucket",
+        "my-object",
+    )
+    await uploader.upload_part(b"hello ", 1)
+    await uploader.upload_part(b"world", 2)
+    result = await uploader.complete()
+    print(
+        "created {0} object; etag: {1}, version-id: {2}".format(
+            result.object_name,
+            result.etag,
+            result.version_id,
+        ),
+    )
+
+    # Abort
+    print("example three")
+    uploader = client.multipart_uploader(
+        "my-bucket",
+        "my-object",
+    )
+    await uploader.upload_part(b"hello ", 1)
+    await uploader.abort()
+
+    # Parallel upload
+    print("example four")
+    tasks = []
+    async with client.multipart_uploader(
+        "my-bucket",
+        "my-object",
+    ) as uploader:
+        for i in range(1, 11):
+            data = f"part {i}".encode("utf-8")
+            tasks.append(uploader.upload_part(data, i))
+        await asyncio.gather(*tasks)
+    result = uploader.result
+    print(
+        "created {0} object; etag: {1}, version-id: {2}".format(
+            result.object_name,
+            result.etag,
+            result.version_id,
+        ),
+    )
+
+
+asyncio.run(main())

--- a/miniopy_async/api.py
+++ b/miniopy_async/api.py
@@ -2346,7 +2346,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                     "my-bucket",
                     "my-object",
                 ) as uploader:
-                    await uploader.upload_part(b"hello ", 1)
+                    await uploader.upload_part(b"hello" * 1024 * 1024, 1)
                     await uploader.upload_part(b"world", 2)
                 result = uploader.result
                 print(
@@ -2363,7 +2363,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                     "my-bucket",
                     "my-object",
                 )
-                await uploader.upload_part(b"hello ", 1)
+                await uploader.upload_part(b"hello" * 1024 * 1024, 1)
                 await uploader.upload_part(b"world", 2)
                 result = await uploader.complete()
                 print(
@@ -2380,7 +2380,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                     "my-bucket",
                     "my-object",
                 )
-                await uploader.upload_part(b"hello ", 1)
+                await uploader.upload_part(b"hello", 1)
                 await uploader.abort()
 
                 # Parallel upload
@@ -2391,7 +2391,7 @@ class Minio:  # pylint: disable=too-many-public-methods
                     "my-object",
                 ) as uploader:
                     for i in range(1, 11):
-                        data = f"part {i}".encode("utf-8")
+                        data = (f"part{i}" * 1024 * 1024).encode("utf-8")
                         tasks.append(uploader.upload_part(data, i))
                     await asyncio.gather(*tasks)
                 result = uploader.result

--- a/miniopy_async/api.py
+++ b/miniopy_async/api.py
@@ -2309,26 +2309,31 @@ class Minio:  # pylint: disable=too-many-public-methods
     @asynccontextmanager
     async def managed_upload(self, bucket_name: str, object_name : str, headers: dict[str, Any] | None = None) -> AsyncIterator[Callable[[bytes, int | None], Awaitable[None]]]:
         """
-        管理异步文件上传的上下文管理器。
-        去除对upload_id 和上传异常的关心，让上传代码只关心自己应该关心的
+        A context manager for asynchronous file uploads.
+        Handles upload_id and exceptions internally, allowing upload code to focus on its core responsibility.
 
         Args:
-            object_name (str): 目标对象的名称。
-            headers (dict[str, Any] | None): 可选的请求头信息。
+            bucket_name (str): Name of the bucket to upload the object to.
+            object_name (str): Name of the target object.
+            headers (dict[str, Any] | None): Optional request headers.
 
         Yields:
-            AsyncIterator[Callable[[bytes, int], Awaitable[None]]]: 生成一个异步上传函数，用于分块上传数据。
+            AsyncIterator[Callable[[bytes, int | None], Awaitable[None]]]: An async upload function for chunked data upload.
 
-        Examples:
-            >>> async with self.managed_upload("example.txt") as uploader:
+        Examples 1:
+            >>> client = Minio("s3.amazonaws.com", "ACCESS-KEY", "SECRET-KEY")
+            ... async with client.managed_upload("example.txt") as uploader:
+            ...     await uploader(b"chunck0")  # ignore part_number, start with 1
+            ...     await uploader(b"chunck1")
+            ...     await uploader(b"chunck2")
+
+        Examples 2:
+            >>> client = Minio("s3.amazonaws.com", "ACCESS-KEY", "SECRET-KEY")
+            ... async with client.managed_upload("example.txt") as uploader:
             ...     await uploader(b"chunck0", 1)
             ...     await uploader(b"chunck1", 2)
             ...     await uploader(b"chunck2", 3)
 
-            >>> async with self.managed_upload("example.txt") as uploader:
-            ...     await uploader(b"chunck0")  # ignore part_number, start with 1
-            ...     await uploader(b"chunck1")
-            ...     await uploader(b"chunck2")
         """
         upload_id = None
         try:

--- a/tests.py
+++ b/tests.py
@@ -9,7 +9,7 @@ from typing import cast
 
 from faker import Faker
 
-from miniopy_async import Minio
+from miniopy_async import Minio, S3Error
 from miniopy_async.commonconfig import (
     ENABLED,
     ComposeSource,
@@ -262,6 +262,61 @@ class Test(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result.bucket_name, self.bucket_name)
         self.assertEqual(result.object_name, compose_name)
+
+    async def test_multipart_uploader(self):
+        test_part1 = fake.binary(5 * 1024 * 1024)
+        test_part2 = fake.binary(1 * 1024 * 1024)
+
+        async with self.client.multipart_uploader(
+            self.bucket_name, self.test_file_name
+        ) as uploader:
+            await uploader.upload_part(test_part1, part_number=1)
+            await uploader.upload_part(test_part2, part_number=2)
+        result = uploader.result
+        self.assertEqual(result.bucket_name, self.bucket_name)
+        self.assertEqual(result.object_name, self.test_file_name)
+        self.assertEqual(
+            await (
+                await self.client.get_object(self.bucket_name, self.test_file_name)
+            ).read(),
+            test_part1 + test_part2,
+        )
+
+        test_part1 = fake.binary(5 * 1024 * 1024)
+        test_part2 = fake.binary(1 * 1024 * 1024)
+
+        uploader = self.client.multipart_uploader(self.bucket_name, self.test_file_name)
+        await uploader.upload_part(test_part1, part_number=1)
+        await uploader.upload_part(test_part2, part_number=2)
+        result = await uploader.complete()
+        self.assertEqual(result.bucket_name, self.bucket_name)
+        self.assertEqual(result.object_name, self.test_file_name)
+        self.assertEqual(
+            await (
+                await self.client.get_object(self.bucket_name, self.test_file_name)
+            ).read(),
+            test_part1 + test_part2,
+        )
+
+        await self.client.remove_object(self.bucket_name, self.test_file_name)
+        uploader = self.client.multipart_uploader(self.bucket_name, self.test_file_name)
+        await uploader.upload_part(test_part1, part_number=1)
+        await uploader.abort()
+        with self.assertRaises(ValueError):
+            uploader.result
+        with self.assertRaises(S3Error):
+            await self.client.stat_object(self.bucket_name, self.test_file_name)
+
+        test_part1 = fake.binary(1 * 1024 * 1024)
+        test_part2 = fake.binary(5 * 1024 * 1024)
+
+        uploader = self.client.multipart_uploader(self.bucket_name, self.test_file_name)
+        await uploader.upload_part(test_part1, part_number=1)
+        await uploader.upload_part(test_part2, part_number=2)
+        with self.assertRaises(S3Error):
+            await uploader.complete()
+        with self.assertRaises(S3Error):
+            await self.client.stat_object(self.bucket_name, self.test_file_name)
 
     async def test_copy_object(self):
         await self.put_test_file()


### PR DESCRIPTION
Thank you for your great work on making true async I/O operations with Minio more accessible through this project.

In my work with miniopy-async, I noticed an opportunity to ‌simplify upload logic by abstracting away upload_id and exception handling‌. This PR introduces a cleaner interface for async uploads—hopefully it'll be useful for others too! 😊

Key improvements:

 * Removes manual `upload_id` tracking
 * Handles exceptions automatically
 * Provides a more intuitive API with `async with`

## Without using `managed_upload` :disappointed: 
```python
async def upload_file(bucket_name, object_name: str, headers: dict[str, Any] | None = None) -> None:
    upload_id = None
    parts = []
    try:
        client = Minio(...)
        if not headers:
            headers = {}
        upload_id = await client._create_multipart_upload(bucket_name, object_name, headers)
   
        async def uploader(data: bytes, part_number: int) -> None:
            etag = await client._upload_part(self.bucket_name, object_name, data, headers, upload_id, part_number)
            parts.append(Part(part_number, etag))

        await uploader(b"chunck0", 1)
        await uploader(b"chunck1", 2)
        await uploader(b"chunck2", 3)

        await client._complete_multipart_upload(bucket_name, object_name, upload_id, parts)
    except Exception as e:
        if upload_id:
            await client._abort_multipart_upload(bucket_name, object_name, upload_id)
        raise
```
### Issues

* Manual context management: Requires manual invocation of upload logic, making it easy to miss exception handling or resource cleanup.
* Code duplication: Each upload requires rewriting exception handling and resource cleanup logic.
* Poor readability: Upload logic is mixed with context management logic.

## After using `managed_upload` :smiley: 
```python
client = Minio(...)
async with client.managed_upload("bucket01", "example.txt") as uploader:
    await uploader(b"chunck0")
    await uploader(b"chunck1")
    await uploader(b"chunck2")
```

```python
client = Minio(...)
async with client.managed_upload("bucket01", "example.txt") as uploader:
    await uploader(b"chunck0", 1)
    await uploader(b"chunck1", 2)
    await uploader(b"chunck2", 3)
```
### Improvements

* Automatic context management: Uses `@asynccontextmanager` to automatically handle exceptions and resource cleanup.
* Code reuse: Separates upload logic from context management, allowing `managed_upload` method to be reused.
* Better readability: Uses `async with` syntax for more intuitive and clearer logic.

## Advantages

No need to worry about upload_id and exception handling - just focus on the upload logic.
More concise code that's easier to maintain.

---------------

Let me know if you'd like any adjustments!