### PR TITLE
Fix object_name urlencoding

### DIFF
--- a/miniopy_async/api.py
+++ b/miniopy_async/api.py
@@ -36,6 +36,7 @@ from urllib.parse import urlunsplit
 from xml.etree import ElementTree as ET
 
 import certifi
+import yarl
 from aiohttp import ClientResponse, ClientSession, ClientTimeout, TCPConnector
 from aiohttp.typedefs import LooseHeaders
 from aiohttp_retry import ExponentialRetry, RetryClient
@@ -362,9 +363,10 @@ class Minio:  # pylint: disable=too-many-public-methods
         self._ensure_session()
         session = cast(ClientSession | RetryClient, self._session)
 
+        yarl_url = yarl.URL(urlunsplit(url), encoded=True)
         response = await session.request(
             method,
-            urlunsplit(url),
+            yarl_url,
             data=body,
             headers=http_headers,
         )


### PR DESCRIPTION
Requests to s3 fail to pass signature check when object names with special symbols are used (':' and others that require escaping) because aiohttp automatically unescapes urlencoded urls (expands % notation).  
This PR fixes this by wrapping s3 urls in `yarl.URL` object with `encoding=True` before passing to aiohttp

Tested with garage s3 server 2.0.0