### PR TITLE
Fix AWS credentials provider

### DIFF
--- a/miniopy_async/credentials/credentials.py
+++ b/miniopy_async/credentials/credentials.py
@@ -70,7 +70,7 @@ class Credentials:
     def is_expired(self) -> bool:
         """Check whether this credentials expired or not."""
         return (
-            self._expiration < (utcnow() + timedelta(seconds=10))
+            self._expiration < (datetime.now() + timedelta(seconds=10))
             if self._expiration
             else False
         )

--- a/miniopy_async/credentials/providers.py
+++ b/miniopy_async/credentials/providers.py
@@ -449,7 +449,7 @@ class IamAwsProvider(Provider):
             return self._credentials
 
         url = self._custom_endpoint
-        if self._token_file:
+        if self._identity_file:
             if not url:
                 url = "https://sts.amazonaws.com"
                 if self._aws_region:


### PR DESCRIPTION
1) Even if we explicitly remove the timezone for the calculated expiration time, `utcnow()` helper still uses time-zoned time, so we fail with `can't compare offset-naive and offset-aware datetimes`
2) No idea what is happening with all those files and endpoints, but an LLM diagnosed this as the root cause, and after monkey patching it, it works for me